### PR TITLE
feat: pydantic response_format + upstream watch + anthropic gaps #5-7

### DIFF
--- a/.github/workflows/upstream-watch.yml
+++ b/.github/workflows/upstream-watch.yml
@@ -12,14 +12,73 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v4
-      - name: Run upstream watcher
-        run: uv run python scripts/upstream_watch.py --create-issue
+
+      - name: Detect upstream drift
+        id: watch
+        run: |
+          uv run python scripts/upstream_watch.py \
+            --create-issue \
+            --keep-clone \
+            --output-dir /tmp/upstream_watch
+          if [ -f /tmp/upstream_watch/has_actionable ]; then
+            echo "has_actionable=true" >> "$GITHUB_OUTPUT"
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Commit updated snapshots
-        if: always()
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add scripts/upstream_snapshots/
           git diff --cached --quiet || (git commit -m "chore: update upstream snapshots" && git push)
+
+      # --- Pi agent analysis (only when actionable changes found) ---
+      # Credentials are stripped before Pi runs: git auth removed,
+      # GH_TOKEN/GITHUB_TOKEN blanked. Pi can read files and run tests
+      # but cannot push, create issues, or call gh CLI.
+
+      - uses: actions/setup-node@v4
+        if: steps.watch.outputs.has_actionable == 'true'
+        with:
+          node-version: '22'
+
+      - name: Install Pi agent
+        if: steps.watch.outputs.has_actionable == 'true'
+        run: npm install -g @mariozechner/pi-coding-agent
+
+      - name: Remove GitHub credentials before Pi
+        if: steps.watch.outputs.has_actionable == 'true'
+        run: git config --unset-all http.https://github.com/.extraheader || true
+
+      - name: Analyze upstream changes
+        if: steps.watch.outputs.has_actionable == 'true'
+        timeout-minutes: 15
+        run: |
+          pi --tools read,bash,grep,find,ls \
+             --provider openrouter \
+             --model "${ANALYSIS_MODEL}" \
+             --no-session \
+             -p @/tmp/upstream_watch/pi_prompt.md \
+             < /dev/null \
+             > /tmp/upstream_watch/analysis.md \
+             2> /tmp/upstream_watch/pi.log
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          ANALYSIS_MODEL: moonshotai/kimi-k2.5
+          GH_TOKEN: ""
+          GITHUB_TOKEN: ""
+
+      - name: Post analysis to issue
+        if: steps.watch.outputs.has_actionable == 'true'
+        run: |
+          if [ -s /tmp/upstream_watch/analysis.md ]; then
+            issue_num=$(cat /tmp/upstream_watch/issue_number.txt)
+            gh issue comment "$issue_num" \
+              --body "## Pi Agent Analysis"$'\n\n'"$(cat /tmp/upstream_watch/analysis.md)"
+          else
+            echo "::warning::Pi agent produced no output"
+            cat /tmp/upstream_watch/pi.log || true
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/litelm/_completion.py
+++ b/litelm/_completion.py
@@ -118,6 +118,50 @@ def _prepare_call(model, kwargs):
     return provider, model_name, base_url, resolved_api_key, resolved_api_version or api_version, num_retries, kwargs
 
 
+def _add_additional_properties_false(schema):
+    """Recursively add additionalProperties: false to object schemas (required by OpenAI strict mode)."""
+    if not isinstance(schema, dict):
+        return schema
+    if schema.get("type") == "object" and "properties" in schema:
+        schema["additionalProperties"] = False
+    for key in ("properties", "$defs", "definitions"):
+        container = schema.get(key)
+        if isinstance(container, dict):
+            for v in container.values():
+                _add_additional_properties_false(v)
+    if "items" in schema and isinstance(schema["items"], dict):
+        _add_additional_properties_false(schema["items"])
+    for variant_key in ("anyOf", "oneOf", "allOf"):
+        variants = schema.get(variant_key)
+        if isinstance(variants, list):
+            for v in variants:
+                _add_additional_properties_false(v)
+    return schema
+
+
+def _normalize_response_format(response_format):
+    """Convert pydantic BaseModel classes to OpenAI json_schema dicts."""
+    if response_format is None or isinstance(response_format, (dict, str)):
+        return response_format
+    if isinstance(response_format, type):
+        try:
+            from pydantic import BaseModel
+            if issubclass(response_format, BaseModel):
+                schema = response_format.model_json_schema()
+                _add_additional_properties_false(schema)
+                return {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": response_format.__name__,
+                        "schema": schema,
+                        "strict": True,
+                    },
+                }
+        except ImportError:
+            pass
+    return response_format
+
+
 def _wrap_context_window_error(e):
     """Convert BadRequestError to ContextWindowExceededError if about context length."""
     if is_context_window_error(str(e)):
@@ -134,6 +178,8 @@ def completion(model, messages=None, *, timeout=None, stream=False, shared_sessi
     mock = kwargs.pop("mock_response", None)
     n = kwargs.pop("n", None) or 1
     provider, model_name, base_url, api_key, api_version, num_retries, kwargs = _prepare_call(model, kwargs)
+    if "response_format" in kwargs:
+        kwargs["response_format"] = _normalize_response_format(kwargs["response_format"])
 
     if mock is not None:
         content = str(mock) if mock is not True else "This is a mock request"
@@ -186,6 +232,8 @@ async def acompletion(model, messages=None, *, timeout=None, stream=False, share
     mock = kwargs.pop("mock_response", None)
     n = kwargs.pop("n", None) or 1
     provider, model_name, base_url, api_key, api_version, num_retries, kwargs = _prepare_call(model, kwargs)
+    if "response_format" in kwargs:
+        kwargs["response_format"] = _normalize_response_format(kwargs["response_format"])
 
     if mock is not None:
         content = str(mock) if mock is not True else "This is a mock request"

--- a/litelm/providers/_anthropic.py
+++ b/litelm/providers/_anthropic.py
@@ -68,12 +68,16 @@ def _extract_system(messages):
         if msg.get("role") == "system":
             content = msg.get("content", "")
             if isinstance(content, str):
-                system_parts.append({"type": "text", "text": content})
+                if content:
+                    system_parts.append({"type": "text", "text": content})
             elif isinstance(content, list):
                 for block in content:
                     if isinstance(block, str):
-                        system_parts.append({"type": "text", "text": block})
+                        if block:
+                            system_parts.append({"type": "text", "text": block})
                     elif isinstance(block, dict):
+                        if block.get("type") == "text" and not block.get("text"):
+                            continue
                         system_parts.append(block)
         else:
             conversation.append(msg)
@@ -93,7 +97,10 @@ def _translate_content(content):
         elif isinstance(part, dict):
             ptype = part.get("type", "text")
             if ptype == "text":
-                block = {"type": "text", "text": part.get("text", "")}
+                text = part.get("text", "")
+                if not text and "cache_control" not in part:
+                    continue
+                block = {"type": "text", "text": text}
                 if "cache_control" in part:
                     block["cache_control"] = part["cache_control"]
                 blocks.append(block)
@@ -189,6 +196,38 @@ def _translate_messages(messages):
     return merged
 
 
+_UNSUPPORTED_SCHEMA_FIELDS = frozenset({
+    "maxItems", "minItems", "minimum", "maximum",
+    "exclusiveMinimum", "exclusiveMaximum", "minLength", "maxLength",
+})
+
+
+def _filter_schema(schema):
+    """Recursively strip JSON schema fields unsupported by Anthropic, appending them to description."""
+    if not isinstance(schema, dict):
+        return schema
+    result = {}
+    constraint_labels = []
+    for key, value in schema.items():
+        if key in _UNSUPPORTED_SCHEMA_FIELDS:
+            constraint_labels.append(f"{key}: {value}")
+        elif key == "properties" and isinstance(value, dict):
+            result[key] = {k: _filter_schema(v) for k, v in value.items()}
+        elif key == "items" and isinstance(value, dict):
+            result[key] = _filter_schema(value)
+        elif key in ("$defs", "definitions") and isinstance(value, dict):
+            result[key] = {k: _filter_schema(v) for k, v in value.items()}
+        elif key in ("anyOf", "allOf") and isinstance(value, list):
+            result[key] = [_filter_schema(item) if isinstance(item, dict) else item for item in value]
+        else:
+            result[key] = value
+    if constraint_labels:
+        desc = result.get("description", "")
+        note = "Note: " + ", ".join(constraint_labels) + "."
+        result["description"] = f"{desc} {note}".strip() if desc else note
+    return result
+
+
 def _translate_tools(tools):
     """Translate OpenAI tools format to Anthropic tools format."""
     if not tools:
@@ -200,7 +239,7 @@ def _translate_tools(tools):
             tool_def = {
                 "name": fn["name"],
                 "description": fn.get("description", ""),
-                "input_schema": fn.get("parameters", {"type": "object", "properties": {}}),
+                "input_schema": _filter_schema(fn.get("parameters", {"type": "object", "properties": {}})),
             }
             if "cache_control" in tool:
                 tool_def["cache_control"] = tool["cache_control"]
@@ -247,6 +286,41 @@ def _get_max_tokens(model_name):
         if model_name.startswith(prefix):
             return tokens
     return _DEFAULT_MAX_TOKENS
+
+
+def _is_opus_4_6(model):
+    """Check if a model is Claude Opus 4.6."""
+    m = model.lower().replace("_", "-").replace(".", "-")
+    return "opus-4-6" in m
+
+
+_REASONING_EFFORT_BUDGET = {
+    "minimal": 128,
+    "low": 1024,
+    "medium": 2048,
+    "high": 4096,
+}
+
+
+def _map_reasoning_effort(reasoning_effort, model_name):
+    """Map OpenAI reasoning_effort to Anthropic thinking/output_config params.
+
+    Returns (thinking_dict_or_None, output_config_or_None).
+    """
+    if not reasoning_effort or str(reasoning_effort).lower() == "none":
+        return None, None
+
+    effort = str(reasoning_effort).lower()
+
+    if _is_opus_4_6(model_name):
+        thinking = {"type": "adaptive"}
+        output_config = {"effort": effort} if effort in ("low", "medium", "high") else None
+        return thinking, output_config
+
+    budget = _REASONING_EFFORT_BUDGET.get(effort)
+    if budget is None:
+        return None, None
+    return {"type": "enabled", "budget_tokens": budget}, None
 
 
 def _build_request_kwargs(model_name, messages, stream, api_key, base_url, **kwargs):
@@ -298,6 +372,14 @@ def _build_request_kwargs(model_name, messages, stream, api_key, base_url, **kwa
     if thinking:
         req["thinking"] = thinking
 
+    reasoning_effort = kwargs.pop("reasoning_effort", None)
+    if reasoning_effort and not thinking:
+        thinking_param, output_config = _map_reasoning_effort(reasoning_effort, model_name)
+        if thinking_param:
+            req["thinking"] = thinking_param
+        if output_config:
+            req["output_config"] = output_config
+
     for drop in (
         "frequency_penalty",
         "presence_penalty",
@@ -307,6 +389,7 @@ def _build_request_kwargs(model_name, messages, stream, api_key, base_url, **kwa
         "n",
         "extra_headers",
         "response_format",
+        "reasoning_effort",
     ):
         kwargs.pop(drop, None)
 

--- a/scripts/upstream_watch.py
+++ b/scripts/upstream_watch.py
@@ -414,8 +414,39 @@ def diff_snapshots(old: dict[str, dict], new: dict[str, dict], ours: dict) -> li
 
 
 # ---------------------------------------------------------------------------
+# Change classification
+# ---------------------------------------------------------------------------
+
+_ACTIONABLE_KEYWORDS = ("We ", "Check our", "May need", "Already in our")
+
+
+def _is_actionable(change: dict) -> bool:
+    """Check if a change requires action on our side."""
+    return any(kw in change["impact"] for kw in _ACTIONABLE_KEYWORDS)
+
+
+# ---------------------------------------------------------------------------
 # Report / issue formatting
 # ---------------------------------------------------------------------------
+
+
+def _format_change_table(changes: list[dict]) -> list[str]:
+    """Format changes as markdown tables grouped by category."""
+    lines: list[str] = []
+    categories: dict[str, list[dict]] = {}
+    for c in changes:
+        categories.setdefault(c["category"], []).append(c)
+    for cat in ["API Surface", "Types", "Exceptions", "Providers"]:
+        if cat not in categories:
+            continue
+        lines.append(f"#### {cat}")
+        lines.append("")
+        lines.append("| Change | Name | Detail | Impact |")
+        lines.append("|--------|------|--------|--------|")
+        for c in categories[cat]:
+            lines.append(f"| {c['change']} | {c['name']} | {c['detail']} | {c['impact']} |")
+        lines.append("")
+    return lines
 
 
 def format_report(changes: list[dict], old_meta: dict, new_meta: dict) -> str:
@@ -428,36 +459,218 @@ def format_report(changes: list[dict], old_meta: dict, new_meta: dict) -> str:
     lines = [
         "## Upstream litellm changes detected",
         "",
-        f"**Commit:** [`{new_commit}`](https://github.com/BerriAI/litellm/commit/{new_commit_full}) (prev: `{old_commit}`)",
+        f"**Range:** [`{old_commit}...{new_commit}`](https://github.com/BerriAI/litellm/compare/{old_commit_full}...{new_commit_full})",
         "",
     ]
 
-    # Group by category
-    categories = {}
-    for c in changes:
-        categories.setdefault(c["category"], []).append(c)
+    actionable = [c for c in changes if _is_actionable(c)]
+    informational = [c for c in changes if not _is_actionable(c)]
 
-    for cat in ["API Surface", "Types", "Exceptions", "Providers"]:
-        if cat not in categories:
-            continue
-        lines.append(f"### {cat}")
-        lines.append("")
-        lines.append("| Change | Name | Detail | litelm impact |")
-        lines.append("|--------|------|--------|---------------|")
-        for c in categories[cat]:
-            lines.append(f"| {c['change']} | {c['name']} | {c['detail']} | {c['impact']} |")
-        lines.append("")
-
-    # Suggested actions
-    has_impact = [c for c in changes if "We" in c["impact"] or "Check" in c["impact"] or "May need" in c["impact"]]
-    if has_impact:
+    if actionable:
+        lines.extend(_format_change_table(actionable))
         lines.append("### Suggested actions")
         lines.append("")
-        for c in has_impact:
+        for c in actionable:
             lines.append(f"- [ ] {c['change']} {c['name']}: {c['impact']}")
         lines.append("")
 
+    if informational:
+        lines.append("<details>")
+        lines.append(f"<summary>{len(informational)} other change(s) outside our scope</summary>")
+        lines.append("")
+        lines.extend(_format_change_table(informational))
+        lines.append("</details>")
+        lines.append("")
+
+    if not actionable:
+        lines.append("*No actionable changes — all detected drift is outside our scope.*")
+        lines.append("")
+
     return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Commit log extraction (runs in watch script, before Pi)
+# ---------------------------------------------------------------------------
+
+_UPSTREAM_FILES = [
+    "litellm/main.py",
+    "litellm/__init__.py",
+    "litellm/types/utils.py",
+    "litellm/exceptions.py",
+    "litellm/llms/anthropic/",
+    "litellm/llms/bedrock/",
+    "litellm/llms/mistral/",
+]
+
+_OUR_FILES = [
+    "litelm/_completion.py",
+    "litelm/_types.py",
+    "litelm/_exceptions.py",
+    "litelm/_embedding.py",
+    "litelm/providers/_anthropic.py",
+    "litelm/providers/_bedrock.py",
+    "litelm/providers/_mistral.py",
+    "litelm/__init__.py",
+]
+
+# Upstream → our implementation mapping
+_FILE_MAP = {
+    "litellm/main.py": "litelm/_completion.py",
+    "litellm/__init__.py": "litelm/__init__.py",
+    "litellm/types/utils.py": "litelm/_types.py",
+    "litellm/exceptions.py": "litelm/_exceptions.py",
+    "litellm/llms/anthropic/": "litelm/providers/_anthropic.py",
+    "litellm/llms/bedrock/": "litelm/providers/_bedrock.py",
+    "litellm/llms/mistral/": "litelm/providers/_mistral.py",
+}
+
+
+def fetch_commit_log(old_commit: str, new_commit: str) -> str:
+    """Fetch relevant commits between old and new from GitHub API."""
+    import urllib.request
+    import urllib.error
+
+    url = f"https://api.github.com/repos/BerriAI/litellm/compare/{old_commit[:12]}...{new_commit[:12]}"
+    try:
+        req = urllib.request.Request(url, headers={"Accept": "application/vnd.github.v3+json"})
+        token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+        if token:
+            req.add_header("Authorization", f"token {token}")
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read())
+    except (urllib.error.URLError, json.JSONDecodeError, OSError) as e:
+        return f"ERROR: could not fetch commit log: {e}"
+
+    commits = data.get("commits", [])
+    files = data.get("files", [])
+
+    relevant_prefixes = tuple(f.rstrip("/") for f in _UPSTREAM_FILES)
+    relevant_files = [f for f in files if any(f["filename"].startswith(p) for p in relevant_prefixes)]
+
+    lines = [f"{len(commits)} total commits, {len(files)} files changed, "
+             f"{len(relevant_files)} in scope\n"]
+
+    if relevant_files:
+        lines.append("Files changed in our scope:")
+        for f in relevant_files:
+            lines.append(f"  {f['filename']} (+{f.get('additions', 0)}/-{f.get('deletions', 0)})")
+        lines.append("")
+
+    lines.append("Commits:")
+    for c in commits:
+        lines.append(f"  {c['sha'][:7]} {c['commit']['message'].splitlines()[0]}")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Pi agent prompt generation
+# ---------------------------------------------------------------------------
+
+
+def generate_pi_prompt(
+    commit_log: str, old_meta: dict, new_meta: dict, clone_path: str,
+) -> str:
+    """Generate verification prompt for the Pi agent."""
+    old_commit = old_meta.get("commit", "unknown")
+    new_commit = new_meta.get("commit", "unknown")
+
+    file_map_str = "\n".join(
+        f"  {up} → {ours}" for up, ours in _FILE_MAP.items()
+    )
+
+    return f"""# Upstream Behavioral Verification
+
+## Your role
+You are a verification agent for litelm, a 2,660 LOC reimplementation of litellm's
+core routing+formatting. A structural AST diff has already detected field/signature
+changes and is posted in the GitHub issue. Your job is different: find what the AST
+diff CANNOT see — behavioral changes inside function bodies, bug fixes, new edge
+cases — and verify every finding with evidence.
+
+## Rules
+1. **Every claim requires evidence.** Show the command and its output. "I believe X"
+   is not a finding. "Verified: `grep -n reasoning_items litelm/_types.py` → 0 hits"
+   is a finding.
+2. **Do not restate the structural diff.** It is already in the issue. You add zero
+   value by repeating it.
+3. **If you find nothing new, say so.** "No behavioral divergences found beyond the
+   structural diff." is a valid and useful report. Padding is worse than silence.
+4. **Do not speculate about impact.** Either verify it or mark it "needs investigation."
+
+## Upstream clone
+{clone_path}
+
+## File mapping (upstream → ours)
+{file_map_str}
+
+## Commit log (fetched by watch script)
+{commit_log}
+
+## Compare
+https://github.com/BerriAI/litellm/compare/{old_commit}...{new_commit}
+
+## Procedure
+
+### 1. Identify in-scope commits
+From the commit log above, filter for commits touching files in the file mapping.
+Ignore commits to Router, proxy, caching, budgeting, callbacks, model registries.
+
+### 2. Read upstream source at changed locations
+For each in-scope file that changed, read the upstream version at `{clone_path}/`
+and compare the behavioral logic against our implementation. Look for:
+- Logic changes inside function bodies (invisible to AST diff)
+- Bug fixes we may need to port
+- New error handling or edge cases
+- Changed streaming behavior or message translation
+
+### 3. Verify each finding
+For each potential divergence:
+a) Show the upstream code (file:line, quote the relevant lines)
+b) Show our code (file:line, quote the relevant lines)
+c) Run a verification command (grep, test, or comparison) that proves the
+   divergence exists or matters
+
+### 4. Check DSPy impact
+For any field or function that changed, verify whether DSPy actually uses it:
+```bash
+# Clone is at {clone_path} — DSPy source may not be available locally.
+# Instead, grep our own codebase and CLAUDE.md for DSPy touchpoints.
+grep -rn "reasoning_items\\|<field_name>" litelm/ CLAUDE.md
+```
+
+### 5. Run our tests
+```bash
+uv run pytest tests/ --ignore=tests/ported --timeout=10 -q
+```
+
+## Output format
+
+Use this structure for each finding. If no findings, skip to the verdict.
+
+### Finding: [short title]
+**Upstream:** `file:line` — [quote changed code]
+**Ours:** `file:line` — [quote our code]
+**Evidence:**
+```
+[command you ran]
+[its output]
+```
+**Verdict:** actionable / not actionable / needs investigation
+
+---
+
+### Test results
+```
+[paste test output]
+```
+
+### Bottom line
+[One sentence: what we should do, or "nothing — no behavioral divergences found."]
+
+Do NOT modify any files. Read-only analysis.
+"""
 
 
 # ---------------------------------------------------------------------------
@@ -487,12 +700,29 @@ def clone_litellm(target: Path) -> str:
 # ---------------------------------------------------------------------------
 
 
-def create_or_comment_issue(body: str, dry_run: bool = False) -> None:
-    """Create a new issue or comment on existing open upstream-watch issue."""
+def _ensure_label(name: str, color: str = "0e8a16", description: str = "") -> None:
+    """Create a GitHub label if it doesn't exist."""
+    result = subprocess.run(
+        ["gh", "label", "list", "--search", name, "--json", "name"],
+        capture_output=True, text=True,
+    )
+    if result.returncode == 0:
+        labels = json.loads(result.stdout) if result.stdout.strip() else []
+        if any(lb["name"] == name for lb in labels):
+            return
+    cmd = ["gh", "label", "create", name, "--color", color]
+    if description:
+        cmd += ["--description", description]
+    subprocess.run(cmd, capture_output=True, text=True)
+
+
+def create_or_comment_issue(body: str, dry_run: bool = False) -> int | None:
+    """Create a new issue or comment on existing. Returns issue number or None."""
     if dry_run:
-        print("=== DRY RUN: Issue body ===")
-        print(body)
-        return
+        print("=== DRY RUN: would create/comment on upstream-watch issue ===")
+        return None
+
+    _ensure_label("upstream-watch", color="0e8a16", description="Automated upstream litellm drift detection")
 
     # Check for existing open issue
     result = subprocess.run(
@@ -508,22 +738,62 @@ def create_or_comment_issue(body: str, dry_run: bool = False) -> None:
                 check=True, capture_output=True, text=True,
             )
             print(f"Commented on issue #{issue_num}")
-            return
+            return issue_num
 
     # Create new issue
-    subprocess.run(
+    result = subprocess.run(
         ["gh", "issue", "create",
          "--title", "Upstream litellm drift detected",
          "--label", "upstream-watch",
          "--body", body],
-        check=True, capture_output=True, text=True,
+        capture_output=True, text=True,
     )
-    print("Created new upstream-watch issue")
+    if result.returncode != 0:
+        print(f"gh issue create stderr: {result.stderr}", file=sys.stderr)
+        result.check_returncode()  # raises CalledProcessError
+    url = result.stdout.strip()
+    issue_num = int(url.rstrip("/").split("/")[-1])
+    print(f"Created new upstream-watch issue: {url}")
+    return issue_num
 
 
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
+
+
+def _write_output_dir(
+    output_dir: str,
+    report: str,
+    old_meta: dict,
+    new_meta: dict,
+    clone_path: str,
+    issue_num: int | None,
+    has_actionable: bool,
+) -> None:
+    """Write analysis artifacts for the Pi agent step."""
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    (out / "report.md").write_text(report)
+    (out / "meta.json").write_text(json.dumps({
+        "old_commit": old_meta.get("commit", "unknown"),
+        "new_commit": new_meta.get("commit", "unknown"),
+    }, indent=2) + "\n")
+
+    # Fetch commit log (has network + GH_TOKEN here, Pi may not)
+    old_commit = old_meta.get("commit", "unknown")
+    new_commit = new_meta.get("commit", "unknown")
+    commit_log = fetch_commit_log(old_commit, new_commit)
+    (out / "commit_log.txt").write_text(commit_log)
+    print(f"Fetched commit log: {commit_log.splitlines()[0]}")
+
+    (out / "pi_prompt.md").write_text(
+        generate_pi_prompt(commit_log, old_meta, new_meta, clone_path)
+    )
+    if has_actionable:
+        (out / "has_actionable").write_text("true\n")
+    if issue_num is not None:
+        (out / "issue_number.txt").write_text(str(issue_num) + "\n")
 
 
 def main() -> int:
@@ -534,6 +804,9 @@ def main() -> int:
     parser.add_argument("--create-issue", action="store_true", help="Create/comment GH issue if changes found")
     parser.add_argument("--dry-run", action="store_true", help="Print issue body without calling gh")
     parser.add_argument("--local", type=str, help="Use existing litellm clone at this path")
+    parser.add_argument("--keep-clone", action="store_true", help="Keep litellm clone for downstream analysis")
+    parser.add_argument("--output-dir", type=str, metavar="DIR",
+                        help="Write analysis artifacts (report, Pi prompt, meta) to DIR")
     args = parser.parse_args()
 
     # Resolve litellm source dir
@@ -546,6 +819,7 @@ def main() -> int:
                 print(f"ERROR: {local_path / 'litellm'} not found", file=sys.stderr)
                 return 2
             litellm_dir = local_path / "litellm"
+            clone_root = str(local_path)
             # Try to get commit hash
             try:
                 result = subprocess.run(
@@ -563,6 +837,7 @@ def main() -> int:
                 print(f"ERROR: git clone failed: {e}", file=sys.stderr)
                 return 2
             litellm_dir = Path(tmpdir) / "litellm"
+            clone_root = tmpdir
 
         # Extract upstream
         new_snapshots = extract_upstream(litellm_dir)
@@ -589,25 +864,43 @@ def main() -> int:
         # Diff
         changes = diff_snapshots(old_snapshots, new_snapshots, ours)
 
-        # Always update snapshots
-        write_snapshots(new_snapshots, new_meta)
-
         if not changes:
+            if not args.dry_run:
+                write_snapshots(new_snapshots, new_meta)
             print("No meaningful upstream changes detected.")
             return 0
 
-        print(f"Found {len(changes)} upstream change(s).")
+        actionable = [c for c in changes if _is_actionable(c)]
         report = format_report(changes, old_meta, new_meta)
+        print(f"Found {len(changes)} change(s) ({len(actionable)} actionable).")
+        print(report)
 
+        issue_num: int | None = None
         if args.create_issue:
-            create_or_comment_issue(report, dry_run=args.dry_run)
-        else:
-            print(report)
+            if actionable:
+                try:
+                    issue_num = create_or_comment_issue(report, dry_run=args.dry_run)
+                except subprocess.CalledProcessError as e:
+                    print(f"ERROR: issue creation failed: {e}", file=sys.stderr)
+                    # Don't update snapshots — next run will re-detect
+                    return 2
+            else:
+                print("No actionable changes — skipping issue creation.")
 
-        return 1
+        # Write analysis artifacts for downstream Pi agent
+        if args.output_dir:
+            _write_output_dir(
+                args.output_dir, report, old_meta, new_meta,
+                clone_root, issue_num, bool(actionable),
+            )
+
+        # Update snapshots after successful reporting (skip in dry-run)
+        if not args.dry_run:
+            write_snapshots(new_snapshots, new_meta)
+        return 0
 
     finally:
-        if tmpdir:
+        if tmpdir and not args.keep_clone:
             shutil.rmtree(tmpdir, ignore_errors=True)
 
 

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -158,3 +158,99 @@ def test_map_openai_error_permission_denied():
 def test_map_openai_error_unprocessable():
     with pytest.raises(UnprocessableEntityError):
         _map_openai_error(_make_openai_error(openai.UnprocessableEntityError, "invalid"))
+
+
+# --- response_format normalization ---
+
+from litelm._completion import _normalize_response_format
+
+
+def test_normalize_response_format_none():
+    assert _normalize_response_format(None) is None
+
+
+def test_normalize_response_format_dict_passthrough():
+    d = {"type": "json_object"}
+    assert _normalize_response_format(d) is d
+
+
+def test_normalize_response_format_str_passthrough():
+    assert _normalize_response_format("json_object") == "json_object"
+
+
+def test_normalize_response_format_pydantic():
+    from pydantic import BaseModel
+
+    class Answer(BaseModel):
+        text: str
+        confidence: float
+
+    result = _normalize_response_format(Answer)
+    assert isinstance(result, dict)
+    assert result["type"] == "json_schema"
+    assert result["json_schema"]["name"] == "Answer"
+    assert result["json_schema"]["strict"] is True
+    schema = result["json_schema"]["schema"]
+    assert schema["type"] == "object"
+    assert "text" in schema["properties"]
+    assert "confidence" in schema["properties"]
+    assert schema["additionalProperties"] is False
+
+
+def test_normalize_response_format_non_pydantic_class():
+    class NotAModel:
+        pass
+
+    assert _normalize_response_format(NotAModel) is NotAModel
+
+
+@mock.patch("litelm._completion.get_sync_client")
+def test_completion_normalizes_pydantic_response_format(mock_get_client):
+    from pydantic import BaseModel
+
+    class Answer(BaseModel):
+        text: str
+
+    mock_client = mock.MagicMock()
+    mock_client.chat.completions.create.return_value = _mock_completion()
+    mock_get_client.return_value = mock_client
+
+    completion(
+        "openai/gpt-4o-mini",
+        messages=[{"role": "user", "content": "hi"}],
+        api_key="sk-test",
+        response_format=Answer,
+    )
+
+    call_kwargs = mock_client.chat.completions.create.call_args[1]
+    rf = call_kwargs["response_format"]
+    assert isinstance(rf, dict)
+    assert rf["type"] == "json_schema"
+    assert rf["json_schema"]["name"] == "Answer"
+
+
+@mock.patch("litelm._completion.get_async_client")
+def test_acompletion_normalizes_pydantic_response_format(mock_get_client):
+    from pydantic import BaseModel
+
+    class Answer(BaseModel):
+        text: str
+
+    mock_client = mock.MagicMock()
+    mock_client.chat.completions.create = mock.AsyncMock(return_value=_mock_completion())
+    mock_get_client.return_value = mock_client
+
+    asyncio.run(
+        acompletion(
+            "openai/gpt-4o-mini",
+            messages=[{"role": "user", "content": "hi"}],
+            api_key="sk-test",
+            response_format=Answer,
+        )
+    )
+
+    call_kwargs = mock_client.chat.completions.create.call_args[1]
+    rf = call_kwargs["response_format"]
+    assert isinstance(rf, dict)
+    assert rf["type"] == "json_schema"
+    assert rf["json_schema"]["name"] == "Answer"

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -409,6 +409,105 @@ class TestAnthropicTranslation:
         assert req["messages"][0]["content"][0]["cache_control"] == {"type": "ephemeral"}
         assert req["tools"][0]["cache_control"] == {"type": "ephemeral"}
 
+    # -- Gap #5: reasoning_effort → thinking/output_config --
+
+    def test_map_reasoning_effort_none(self):
+        assert self.mod._map_reasoning_effort(None, "claude-3-haiku") == (None, None)
+
+    def test_map_reasoning_effort_none_string(self):
+        assert self.mod._map_reasoning_effort("none", "claude-3-haiku") == (None, None)
+
+    def test_map_reasoning_effort_low_standard(self):
+        t, o = self.mod._map_reasoning_effort("low", "claude-sonnet-4-20250514")
+        assert t == {"type": "enabled", "budget_tokens": 1024}
+        assert o is None
+
+    def test_map_reasoning_effort_high_standard(self):
+        t, o = self.mod._map_reasoning_effort("high", "claude-3-7-sonnet-20250219")
+        assert t == {"type": "enabled", "budget_tokens": 4096}
+        assert o is None
+
+    def test_map_reasoning_effort_opus_4_6(self):
+        t, o = self.mod._map_reasoning_effort("high", "claude-opus-4-6-20250514")
+        assert t == {"type": "adaptive"}
+        assert o == {"effort": "high"}
+
+    def test_map_reasoning_effort_opus_4_6_underscore(self):
+        t, o = self.mod._map_reasoning_effort("medium", "claude_opus_4_6")
+        assert t == {"type": "adaptive"}
+        assert o == {"effort": "medium"}
+
+    def test_build_request_kwargs_reasoning_effort(self):
+        msgs = [{"role": "user", "content": "hi"}]
+        req = self.mod._build_request_kwargs("claude-sonnet-4-20250514", msgs, False, None, None, reasoning_effort="medium")
+        assert req["thinking"] == {"type": "enabled", "budget_tokens": 2048}
+        assert "reasoning_effort" not in req
+
+    def test_build_request_kwargs_explicit_thinking_overrides_reasoning_effort(self):
+        msgs = [{"role": "user", "content": "hi"}]
+        req = self.mod._build_request_kwargs("claude-sonnet-4-20250514", msgs, False, None, None,
+            thinking={"type": "enabled", "budget_tokens": 10000}, reasoning_effort="low")
+        assert req["thinking"]["budget_tokens"] == 10000
+
+    # -- Gap #6: empty text block filtering --
+
+    def test_extract_system_filters_empty_string(self):
+        msgs = [{"role": "system", "content": ""}, {"role": "user", "content": "hi"}]
+        system, _ = self.mod._extract_system(msgs)
+        assert system is None
+
+    def test_extract_system_filters_empty_text_block(self):
+        msgs = [{"role": "system", "content": [{"type": "text", "text": ""}]}, {"role": "user", "content": "hi"}]
+        system, _ = self.mod._extract_system(msgs)
+        assert system is None
+
+    def test_extract_system_filters_empty_string_in_list(self):
+        msgs = [{"role": "system", "content": [""]}, {"role": "user", "content": "hi"}]
+        system, _ = self.mod._extract_system(msgs)
+        assert system is None
+
+    def test_translate_content_filters_empty_text(self):
+        result = self.mod._translate_content([
+            {"type": "text", "text": ""},
+            {"type": "text", "text": "hello"},
+        ])
+        assert result == [{"type": "text", "text": "hello"}]
+
+    # -- Gap #7: JSON schema filtering --
+
+    def test_filter_schema_strips_unsupported(self):
+        schema = {"type": "object", "properties": {
+            "count": {"type": "integer", "minimum": 1, "maximum": 100}
+        }}
+        result = self.mod._filter_schema(schema)
+        assert "minimum" not in result["properties"]["count"]
+        assert "maximum" not in result["properties"]["count"]
+        assert "minimum: 1" in result["properties"]["count"]["description"]
+
+    def test_filter_schema_preserves_supported(self):
+        schema = {"type": "object", "properties": {"name": {"type": "string"}}}
+        assert self.mod._filter_schema(schema) == schema
+
+    def test_filter_schema_recursive_items(self):
+        schema = {"type": "array", "items": {"type": "string", "minLength": 1}, "minItems": 2}
+        result = self.mod._filter_schema(schema)
+        assert "minItems" not in result
+        assert "minLength" not in result["items"]
+
+    def test_filter_schema_anyof(self):
+        schema = {"anyOf": [{"type": "integer", "minimum": 0}, {"type": "string"}]}
+        result = self.mod._filter_schema(schema)
+        assert "minimum" not in result["anyOf"][0]
+
+    def test_translate_tools_filters_schema(self):
+        tools = [{"type": "function", "function": {
+            "name": "f", "parameters": {"type": "object", "properties": {
+                "n": {"type": "integer", "minimum": 0, "maximum": 10}
+            }}
+        }}]
+        result = self.mod._translate_tools(tools)
+        assert "minimum" not in result[0]["input_schema"]["properties"]["n"]
+
 
 # ---------------------------------------------------------------------------
 # Anthropic error mapping

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -594,3 +594,50 @@ def test_openai_text_completion():
     assert response.choices[0].finish_reason in ("stop", "length")
     assert response.usage.prompt_tokens > 0
     assert response.usage.total_tokens > 0
+
+
+# --- Pydantic response_format ---
+
+from pydantic import BaseModel
+
+
+class StructuredAnswer(BaseModel):
+    answer: str
+    reasoning: str
+
+
+@pytest.mark.live
+@pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY"), reason="no OPENAI_API_KEY")
+def test_openai_pydantic_response_format():
+    """Pydantic BaseModel as response_format — exercises _normalize_response_format."""
+    response = litelm.completion(
+        "openai/gpt-4o-mini",
+        messages=[{"role": "user", "content": "What is 2+2? Explain briefly."}],
+        response_format=StructuredAnswer,
+    )
+    assert_dspy_response_contract(response)
+    content = response.choices[0].message.content
+    parsed = json.loads(content)
+    assert "answer" in parsed
+    assert "reasoning" in parsed
+
+
+@pytest.mark.live
+@pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY"), reason="no OPENAI_API_KEY")
+def test_openai_pydantic_response_format_streaming():
+    """Streaming + pydantic response_format — verify JSON reassembles."""
+    chunks = list(
+        litelm.completion(
+            "openai/gpt-4o-mini",
+            messages=[{"role": "user", "content": "What is 2+2? Explain briefly."}],
+            response_format=StructuredAnswer,
+            stream=True,
+            stream_options={"include_usage": True},
+        )
+    )
+    assert_stream_contract(chunks)
+    response = litelm.stream_chunk_builder(chunks)
+    content = response.choices[0].message.content
+    parsed = json.loads(content)
+    assert "answer" in parsed
+    assert "reasoning" in parsed


### PR DESCRIPTION
## Summary

- **Pydantic response_format (closes #3):** Detect BaseModel classes, convert to json_schema dicts with `strict: true` + `additionalProperties: false`. Works for all OpenAI-compat providers. 7 unit + 2 live tests.
- **Upstream watch fixes:** Fix exit codes, add Pi agent behavioral verification (Kimi K2.5 via OpenRouter), credential sandboxing, commit log extraction, evidence-based prompt.
- **Anthropic gaps #5-7:** reasoning_effort mapping, empty text block filtering, JSON schema filtering. 17 tests.

## Test plan

- [x] 21 unit tests in test_completion.py (all pass)
- [x] 189 total tests pass, 49 skipped, 3 pre-existing env failures
- [x] Live: pydantic response_format with OpenAI (non-streaming + streaming)
- [x] Live: upstream watch end-to-end (issue #5, #6 created and closed)
- [x] Live: Pi agent analysis verified with actual output

🤖 Generated with [Claude Code](https://claude.com/claude-code)