### PR TITLE
feat: azure_ad_token_provider passthrough (closes #2)

### DIFF
--- a/litelm/_client_cache.py
+++ b/litelm/_client_cache.py
@@ -23,8 +23,13 @@ def get_sync_client(provider, base_url, api_key, max_retries=0, api_version=None
         with _lock:
             if key not in _sync_clients:
                 _sync_clients[key] = _make_client(
-                    provider, base_url, api_key, max_retries, api_version,
-                    async_client=False, azure_ad_token_provider=azure_ad_token_provider,
+                    provider,
+                    base_url,
+                    api_key,
+                    max_retries,
+                    api_version,
+                    async_client=False,
+                    azure_ad_token_provider=azure_ad_token_provider,
                 )
     return _sync_clients[key]
 
@@ -35,8 +40,13 @@ def get_async_client(provider, base_url, api_key, max_retries=0, api_version=Non
         with _lock:
             if key not in _async_clients:
                 _async_clients[key] = _make_client(
-                    provider, base_url, api_key, max_retries, api_version,
-                    async_client=True, azure_ad_token_provider=azure_ad_token_provider,
+                    provider,
+                    base_url,
+                    api_key,
+                    max_retries,
+                    api_version,
+                    async_client=True,
+                    azure_ad_token_provider=azure_ad_token_provider,
                 )
     return _async_clients[key]
 

--- a/litelm/_client_cache.py
+++ b/litelm/_client_cache.py
@@ -17,24 +17,26 @@ def _require_openai():
         raise ImportError("The openai SDK is required for this provider. Install it with: pip install litelm[openai]")
 
 
-def get_sync_client(provider, base_url, api_key, max_retries=0, api_version=None):
-    key = ("sync", provider, base_url, api_key, max_retries, api_version)
+def get_sync_client(provider, base_url, api_key, max_retries=0, api_version=None, azure_ad_token_provider=None):
+    key = ("sync", provider, base_url, api_key, max_retries, api_version, id(azure_ad_token_provider))
     if key not in _sync_clients:
         with _lock:
             if key not in _sync_clients:
                 _sync_clients[key] = _make_client(
-                    provider, base_url, api_key, max_retries, api_version, async_client=False
+                    provider, base_url, api_key, max_retries, api_version,
+                    async_client=False, azure_ad_token_provider=azure_ad_token_provider,
                 )
     return _sync_clients[key]
 
 
-def get_async_client(provider, base_url, api_key, max_retries=0, api_version=None):
-    key = ("async", provider, base_url, api_key, max_retries, api_version)
+def get_async_client(provider, base_url, api_key, max_retries=0, api_version=None, azure_ad_token_provider=None):
+    key = ("async", provider, base_url, api_key, max_retries, api_version, id(azure_ad_token_provider))
     if key not in _async_clients:
         with _lock:
             if key not in _async_clients:
                 _async_clients[key] = _make_client(
-                    provider, base_url, api_key, max_retries, api_version, async_client=True
+                    provider, base_url, api_key, max_retries, api_version,
+                    async_client=True, azure_ad_token_provider=azure_ad_token_provider,
                 )
     return _async_clients[key]
 
@@ -47,16 +49,19 @@ async def close_async_clients():
         _async_clients.clear()
 
 
-def _make_client(provider, base_url, api_key, max_retries, api_version, async_client):
+def _make_client(provider, base_url, api_key, max_retries, api_version, async_client, azure_ad_token_provider=None):
     openai = _require_openai()
     if provider == "azure":
         cls = openai.AsyncAzureOpenAI if async_client else openai.AzureOpenAI
-        return cls(
+        azure_kwargs = dict(
             azure_endpoint=base_url,
             api_key=api_key,
             api_version=api_version or "2024-02-01",
             max_retries=max_retries,
         )
+        if azure_ad_token_provider is not None:
+            azure_kwargs["azure_ad_token_provider"] = azure_ad_token_provider
+        return cls(**azure_kwargs)
     else:
         cls = openai.AsyncOpenAI if async_client else openai.OpenAI
         kwargs = {"api_key": api_key, "max_retries": max_retries}

--- a/litelm/_completion.py
+++ b/litelm/_completion.py
@@ -117,8 +117,14 @@ def _prepare_call(model, kwargs):
         kwargs["extra_headers"] = headers
 
     return (
-        provider, model_name, base_url, resolved_api_key,
-        resolved_api_version or api_version, num_retries, azure_ad_token_provider, kwargs,
+        provider,
+        model_name,
+        base_url,
+        resolved_api_key,
+        resolved_api_version or api_version,
+        num_retries,
+        azure_ad_token_provider,
+        kwargs,
     )
 
 
@@ -150,6 +156,7 @@ def _normalize_response_format(response_format):
     if isinstance(response_format, type):
         try:
             from pydantic import BaseModel
+
             if issubclass(response_format, BaseModel):
                 schema = response_format.model_json_schema()
                 _add_additional_properties_false(schema)
@@ -181,8 +188,9 @@ def completion(model, messages=None, *, timeout=None, stream=False, shared_sessi
     """Synchronous chat completion."""
     mock = kwargs.pop("mock_response", None)
     n = kwargs.pop("n", None) or 1
-    (provider, model_name, base_url, api_key, api_version,
-     num_retries, azure_ad_token_provider, kwargs) = _prepare_call(model, kwargs)
+    (provider, model_name, base_url, api_key, api_version, num_retries, azure_ad_token_provider, kwargs) = (
+        _prepare_call(model, kwargs)
+    )
     if "response_format" in kwargs:
         kwargs["response_format"] = _normalize_response_format(kwargs["response_format"])
 
@@ -216,8 +224,12 @@ def completion(model, messages=None, *, timeout=None, stream=False, shared_sessi
         )
 
     client = get_sync_client(
-        provider, base_url, api_key, max_retries=num_retries,
-        api_version=api_version, azure_ad_token_provider=azure_ad_token_provider,
+        provider,
+        base_url,
+        api_key,
+        max_retries=num_retries,
+        api_version=api_version,
+        azure_ad_token_provider=azure_ad_token_provider,
     )
 
     try:
@@ -239,8 +251,9 @@ async def acompletion(model, messages=None, *, timeout=None, stream=False, share
     """Async chat completion."""
     mock = kwargs.pop("mock_response", None)
     n = kwargs.pop("n", None) or 1
-    (provider, model_name, base_url, api_key, api_version,
-     num_retries, azure_ad_token_provider, kwargs) = _prepare_call(model, kwargs)
+    (provider, model_name, base_url, api_key, api_version, num_retries, azure_ad_token_provider, kwargs) = (
+        _prepare_call(model, kwargs)
+    )
     if "response_format" in kwargs:
         kwargs["response_format"] = _normalize_response_format(kwargs["response_format"])
 
@@ -274,8 +287,12 @@ async def acompletion(model, messages=None, *, timeout=None, stream=False, share
         )
 
     client = get_async_client(
-        provider, base_url, api_key, max_retries=num_retries,
-        api_version=api_version, azure_ad_token_provider=azure_ad_token_provider,
+        provider,
+        base_url,
+        api_key,
+        max_retries=num_retries,
+        api_version=api_version,
+        azure_ad_token_provider=azure_ad_token_provider,
     )
 
     try:
@@ -424,11 +441,13 @@ def stream_chunk_builder(chunks):
                         if block.get("signature"):
                             current_thinking_signature = block["signature"]
                             # Flush: signature terminates a thinking block
-                            thinking_blocks.append({
-                                "type": "thinking",
-                                "thinking": "".join(current_thinking_parts),
-                                "signature": current_thinking_signature,
-                            })
+                            thinking_blocks.append(
+                                {
+                                    "type": "thinking",
+                                    "thinking": "".join(current_thinking_parts),
+                                    "signature": current_thinking_signature,
+                                }
+                            )
                             current_thinking_parts = []
                             current_thinking_signature = None
                 if getattr(delta, "images", None):

--- a/litelm/_completion.py
+++ b/litelm/_completion.py
@@ -116,7 +116,10 @@ def _prepare_call(model, kwargs):
     if headers:
         kwargs["extra_headers"] = headers
 
-    return provider, model_name, base_url, resolved_api_key, resolved_api_version or api_version, num_retries, azure_ad_token_provider, kwargs
+    return (
+        provider, model_name, base_url, resolved_api_key,
+        resolved_api_version or api_version, num_retries, azure_ad_token_provider, kwargs,
+    )
 
 
 def _add_additional_properties_false(schema):
@@ -178,7 +181,8 @@ def completion(model, messages=None, *, timeout=None, stream=False, shared_sessi
     """Synchronous chat completion."""
     mock = kwargs.pop("mock_response", None)
     n = kwargs.pop("n", None) or 1
-    provider, model_name, base_url, api_key, api_version, num_retries, azure_ad_token_provider, kwargs = _prepare_call(model, kwargs)
+    (provider, model_name, base_url, api_key, api_version,
+     num_retries, azure_ad_token_provider, kwargs) = _prepare_call(model, kwargs)
     if "response_format" in kwargs:
         kwargs["response_format"] = _normalize_response_format(kwargs["response_format"])
 
@@ -211,7 +215,10 @@ def completion(model, messages=None, *, timeout=None, stream=False, shared_sessi
             model_name, messages, stream=stream, api_key=api_key, base_url=base_url, timeout=timeout, **kwargs
         )
 
-    client = get_sync_client(provider, base_url, api_key, max_retries=num_retries, api_version=api_version, azure_ad_token_provider=azure_ad_token_provider)
+    client = get_sync_client(
+        provider, base_url, api_key, max_retries=num_retries,
+        api_version=api_version, azure_ad_token_provider=azure_ad_token_provider,
+    )
 
     try:
         sdk_kwargs = dict(model=model_name, messages=messages, stream=stream, **kwargs)
@@ -232,7 +239,8 @@ async def acompletion(model, messages=None, *, timeout=None, stream=False, share
     """Async chat completion."""
     mock = kwargs.pop("mock_response", None)
     n = kwargs.pop("n", None) or 1
-    provider, model_name, base_url, api_key, api_version, num_retries, azure_ad_token_provider, kwargs = _prepare_call(model, kwargs)
+    (provider, model_name, base_url, api_key, api_version,
+     num_retries, azure_ad_token_provider, kwargs) = _prepare_call(model, kwargs)
     if "response_format" in kwargs:
         kwargs["response_format"] = _normalize_response_format(kwargs["response_format"])
 
@@ -265,7 +273,10 @@ async def acompletion(model, messages=None, *, timeout=None, stream=False, share
             model_name, messages, stream=stream, api_key=api_key, base_url=base_url, timeout=timeout, **kwargs
         )
 
-    client = get_async_client(provider, base_url, api_key, max_retries=num_retries, api_version=api_version, azure_ad_token_provider=azure_ad_token_provider)
+    client = get_async_client(
+        provider, base_url, api_key, max_retries=num_retries,
+        api_version=api_version, azure_ad_token_provider=azure_ad_token_provider,
+    )
 
     try:
         sdk_kwargs = dict(model=model_name, messages=messages, stream=stream, **kwargs)

--- a/litelm/_completion.py
+++ b/litelm/_completion.py
@@ -106,6 +106,7 @@ def _prepare_call(model, kwargs):
     api_key = kwargs.pop("api_key", None)
     api_base = kwargs.pop("api_base", None) or kwargs.pop("base_url", None)
     api_version = kwargs.pop("api_version", None)
+    azure_ad_token_provider = kwargs.pop("azure_ad_token_provider", None)
     headers = kwargs.pop("headers", None)
 
     provider, model_name, base_url, resolved_api_key, resolved_api_version = parse_model(
@@ -115,7 +116,7 @@ def _prepare_call(model, kwargs):
     if headers:
         kwargs["extra_headers"] = headers
 
-    return provider, model_name, base_url, resolved_api_key, resolved_api_version or api_version, num_retries, kwargs
+    return provider, model_name, base_url, resolved_api_key, resolved_api_version or api_version, num_retries, azure_ad_token_provider, kwargs
 
 
 def _add_additional_properties_false(schema):
@@ -177,7 +178,7 @@ def completion(model, messages=None, *, timeout=None, stream=False, shared_sessi
     """Synchronous chat completion."""
     mock = kwargs.pop("mock_response", None)
     n = kwargs.pop("n", None) or 1
-    provider, model_name, base_url, api_key, api_version, num_retries, kwargs = _prepare_call(model, kwargs)
+    provider, model_name, base_url, api_key, api_version, num_retries, azure_ad_token_provider, kwargs = _prepare_call(model, kwargs)
     if "response_format" in kwargs:
         kwargs["response_format"] = _normalize_response_format(kwargs["response_format"])
 
@@ -210,7 +211,7 @@ def completion(model, messages=None, *, timeout=None, stream=False, shared_sessi
             model_name, messages, stream=stream, api_key=api_key, base_url=base_url, timeout=timeout, **kwargs
         )
 
-    client = get_sync_client(provider, base_url, api_key, max_retries=num_retries, api_version=api_version)
+    client = get_sync_client(provider, base_url, api_key, max_retries=num_retries, api_version=api_version, azure_ad_token_provider=azure_ad_token_provider)
 
     try:
         sdk_kwargs = dict(model=model_name, messages=messages, stream=stream, **kwargs)
@@ -231,7 +232,7 @@ async def acompletion(model, messages=None, *, timeout=None, stream=False, share
     """Async chat completion."""
     mock = kwargs.pop("mock_response", None)
     n = kwargs.pop("n", None) or 1
-    provider, model_name, base_url, api_key, api_version, num_retries, kwargs = _prepare_call(model, kwargs)
+    provider, model_name, base_url, api_key, api_version, num_retries, azure_ad_token_provider, kwargs = _prepare_call(model, kwargs)
     if "response_format" in kwargs:
         kwargs["response_format"] = _normalize_response_format(kwargs["response_format"])
 
@@ -264,7 +265,7 @@ async def acompletion(model, messages=None, *, timeout=None, stream=False, share
             model_name, messages, stream=stream, api_key=api_key, base_url=base_url, timeout=timeout, **kwargs
         )
 
-    client = get_async_client(provider, base_url, api_key, max_retries=num_retries, api_version=api_version)
+    client = get_async_client(provider, base_url, api_key, max_retries=num_retries, api_version=api_version, azure_ad_token_provider=azure_ad_token_provider)
 
     try:
         sdk_kwargs = dict(model=model_name, messages=messages, stream=stream, **kwargs)

--- a/litelm/_text_completion.py
+++ b/litelm/_text_completion.py
@@ -36,7 +36,7 @@ def text_completion(model, prompt, *, timeout=None, shared_session=None, **kwarg
     """Synchronous text completion (legacy completions API)."""
     mock = kwargs.pop("mock_response", None)
     model = _strip_text_prefix(model)
-    provider, model_name, base_url, api_key, api_version, num_retries, kwargs = _prepare_call(model, kwargs)
+    provider, model_name, base_url, api_key, api_version, num_retries, azure_ad_token_provider, kwargs = _prepare_call(model, kwargs)
     if mock is not None:
         from openai.types import Completion, CompletionChoice, CompletionUsage
 
@@ -51,7 +51,7 @@ def text_completion(model, prompt, *, timeout=None, shared_session=None, **kwarg
                 usage=CompletionUsage(prompt_tokens=0, completion_tokens=0, total_tokens=0),
             )
         )
-    client = get_sync_client(provider, base_url, api_key, max_retries=num_retries, api_version=api_version)
+    client = get_sync_client(provider, base_url, api_key, max_retries=num_retries, api_version=api_version, azure_ad_token_provider=azure_ad_token_provider)
     sdk_kwargs = dict(model=model_name, prompt=prompt, **kwargs)
     if timeout is not None:
         sdk_kwargs["timeout"] = timeout
@@ -68,7 +68,7 @@ async def atext_completion(model, prompt, *, timeout=None, shared_session=None, 
     """Async text completion (legacy completions API)."""
     mock = kwargs.pop("mock_response", None)
     model = _strip_text_prefix(model)
-    provider, model_name, base_url, api_key, api_version, num_retries, kwargs = _prepare_call(model, kwargs)
+    provider, model_name, base_url, api_key, api_version, num_retries, azure_ad_token_provider, kwargs = _prepare_call(model, kwargs)
     if mock is not None:
         from openai.types import Completion, CompletionChoice, CompletionUsage
 
@@ -83,7 +83,7 @@ async def atext_completion(model, prompt, *, timeout=None, shared_session=None, 
                 usage=CompletionUsage(prompt_tokens=0, completion_tokens=0, total_tokens=0),
             )
         )
-    client = get_async_client(provider, base_url, api_key, max_retries=num_retries, api_version=api_version)
+    client = get_async_client(provider, base_url, api_key, max_retries=num_retries, api_version=api_version, azure_ad_token_provider=azure_ad_token_provider)
     sdk_kwargs = dict(model=model_name, prompt=prompt, **kwargs)
     if timeout is not None:
         sdk_kwargs["timeout"] = timeout

--- a/litelm/_text_completion.py
+++ b/litelm/_text_completion.py
@@ -36,7 +36,8 @@ def text_completion(model, prompt, *, timeout=None, shared_session=None, **kwarg
     """Synchronous text completion (legacy completions API)."""
     mock = kwargs.pop("mock_response", None)
     model = _strip_text_prefix(model)
-    provider, model_name, base_url, api_key, api_version, num_retries, azure_ad_token_provider, kwargs = _prepare_call(model, kwargs)
+    (provider, model_name, base_url, api_key, api_version,
+     num_retries, azure_ad_token_provider, kwargs) = _prepare_call(model, kwargs)
     if mock is not None:
         from openai.types import Completion, CompletionChoice, CompletionUsage
 
@@ -51,7 +52,10 @@ def text_completion(model, prompt, *, timeout=None, shared_session=None, **kwarg
                 usage=CompletionUsage(prompt_tokens=0, completion_tokens=0, total_tokens=0),
             )
         )
-    client = get_sync_client(provider, base_url, api_key, max_retries=num_retries, api_version=api_version, azure_ad_token_provider=azure_ad_token_provider)
+    client = get_sync_client(
+        provider, base_url, api_key, max_retries=num_retries,
+        api_version=api_version, azure_ad_token_provider=azure_ad_token_provider,
+    )
     sdk_kwargs = dict(model=model_name, prompt=prompt, **kwargs)
     if timeout is not None:
         sdk_kwargs["timeout"] = timeout
@@ -68,7 +72,8 @@ async def atext_completion(model, prompt, *, timeout=None, shared_session=None, 
     """Async text completion (legacy completions API)."""
     mock = kwargs.pop("mock_response", None)
     model = _strip_text_prefix(model)
-    provider, model_name, base_url, api_key, api_version, num_retries, azure_ad_token_provider, kwargs = _prepare_call(model, kwargs)
+    (provider, model_name, base_url, api_key, api_version,
+     num_retries, azure_ad_token_provider, kwargs) = _prepare_call(model, kwargs)
     if mock is not None:
         from openai.types import Completion, CompletionChoice, CompletionUsage
 
@@ -83,7 +88,10 @@ async def atext_completion(model, prompt, *, timeout=None, shared_session=None, 
                 usage=CompletionUsage(prompt_tokens=0, completion_tokens=0, total_tokens=0),
             )
         )
-    client = get_async_client(provider, base_url, api_key, max_retries=num_retries, api_version=api_version, azure_ad_token_provider=azure_ad_token_provider)
+    client = get_async_client(
+        provider, base_url, api_key, max_retries=num_retries,
+        api_version=api_version, azure_ad_token_provider=azure_ad_token_provider,
+    )
     sdk_kwargs = dict(model=model_name, prompt=prompt, **kwargs)
     if timeout is not None:
         sdk_kwargs["timeout"] = timeout

--- a/litelm/_text_completion.py
+++ b/litelm/_text_completion.py
@@ -36,8 +36,9 @@ def text_completion(model, prompt, *, timeout=None, shared_session=None, **kwarg
     """Synchronous text completion (legacy completions API)."""
     mock = kwargs.pop("mock_response", None)
     model = _strip_text_prefix(model)
-    (provider, model_name, base_url, api_key, api_version,
-     num_retries, azure_ad_token_provider, kwargs) = _prepare_call(model, kwargs)
+    (provider, model_name, base_url, api_key, api_version, num_retries, azure_ad_token_provider, kwargs) = (
+        _prepare_call(model, kwargs)
+    )
     if mock is not None:
         from openai.types import Completion, CompletionChoice, CompletionUsage
 
@@ -53,8 +54,12 @@ def text_completion(model, prompt, *, timeout=None, shared_session=None, **kwarg
             )
         )
     client = get_sync_client(
-        provider, base_url, api_key, max_retries=num_retries,
-        api_version=api_version, azure_ad_token_provider=azure_ad_token_provider,
+        provider,
+        base_url,
+        api_key,
+        max_retries=num_retries,
+        api_version=api_version,
+        azure_ad_token_provider=azure_ad_token_provider,
     )
     sdk_kwargs = dict(model=model_name, prompt=prompt, **kwargs)
     if timeout is not None:
@@ -72,8 +77,9 @@ async def atext_completion(model, prompt, *, timeout=None, shared_session=None, 
     """Async text completion (legacy completions API)."""
     mock = kwargs.pop("mock_response", None)
     model = _strip_text_prefix(model)
-    (provider, model_name, base_url, api_key, api_version,
-     num_retries, azure_ad_token_provider, kwargs) = _prepare_call(model, kwargs)
+    (provider, model_name, base_url, api_key, api_version, num_retries, azure_ad_token_provider, kwargs) = (
+        _prepare_call(model, kwargs)
+    )
     if mock is not None:
         from openai.types import Completion, CompletionChoice, CompletionUsage
 
@@ -89,8 +95,12 @@ async def atext_completion(model, prompt, *, timeout=None, shared_session=None, 
             )
         )
     client = get_async_client(
-        provider, base_url, api_key, max_retries=num_retries,
-        api_version=api_version, azure_ad_token_provider=azure_ad_token_provider,
+        provider,
+        base_url,
+        api_key,
+        max_retries=num_retries,
+        api_version=api_version,
+        azure_ad_token_provider=azure_ad_token_provider,
     )
     sdk_kwargs = dict(model=model_name, prompt=prompt, **kwargs)
     if timeout is not None:

--- a/tests/test_client_cache.py
+++ b/tests/test_client_cache.py
@@ -114,34 +114,41 @@ async def test_close_async_clients():
     assert len(_async_clients) == 0
 
 
+def _fake_token():
+    return "fake-token"
+
+
 def test_azure_ad_token_provider_forwarded():
     """azure_ad_token_provider is passed to AzureOpenAI constructor."""
-    provider_fn = lambda: "fake-token"
-    client = get_sync_client("azure", "https://my.azure.com", None, azure_ad_token_provider=provider_fn)
-    assert client._azure_ad_token_provider is provider_fn
+    client = get_sync_client("azure", "https://my.azure.com", None, azure_ad_token_provider=_fake_token)
+    assert client._azure_ad_token_provider is _fake_token
 
 
 def test_azure_ad_token_provider_forwarded_async():
     """azure_ad_token_provider is passed to AsyncAzureOpenAI constructor."""
-    provider_fn = lambda: "fake-token"
-    client = get_async_client("azure", "https://my.azure.com", None, azure_ad_token_provider=provider_fn)
-    assert client._azure_ad_token_provider is provider_fn
+    client = get_async_client("azure", "https://my.azure.com", None, azure_ad_token_provider=_fake_token)
+    assert client._azure_ad_token_provider is _fake_token
+
+
+def _token_a():
+    return "token-a"
+
+
+def _token_b():
+    return "token-b"
 
 
 def test_azure_different_token_providers_not_cached():
     """Different azure_ad_token_provider functions produce different clients."""
-    fn1 = lambda: "token-a"
-    fn2 = lambda: "token-b"
-    c1 = get_sync_client("azure", "https://x.azure.com", None, azure_ad_token_provider=fn1)
-    c2 = get_sync_client("azure", "https://x.azure.com", None, azure_ad_token_provider=fn2)
+    c1 = get_sync_client("azure", "https://x.azure.com", None, azure_ad_token_provider=_token_a)
+    c2 = get_sync_client("azure", "https://x.azure.com", None, azure_ad_token_provider=_token_b)
     assert c1 is not c2
 
 
 def test_azure_same_token_provider_cached():
     """Same azure_ad_token_provider function reuses cached client."""
-    fn = lambda: "token"
-    c1 = get_sync_client("azure", "https://x.azure.com", None, azure_ad_token_provider=fn)
-    c2 = get_sync_client("azure", "https://x.azure.com", None, azure_ad_token_provider=fn)
+    c1 = get_sync_client("azure", "https://x.azure.com", None, azure_ad_token_provider=_fake_token)
+    c2 = get_sync_client("azure", "https://x.azure.com", None, azure_ad_token_provider=_fake_token)
     assert c1 is c2
 
 

--- a/tests/test_client_cache.py
+++ b/tests/test_client_cache.py
@@ -112,3 +112,42 @@ async def test_close_async_clients():
     assert len(_async_clients) == 1
     await close_async_clients()
     assert len(_async_clients) == 0
+
+
+def test_azure_ad_token_provider_forwarded():
+    """azure_ad_token_provider is passed to AzureOpenAI constructor."""
+    provider_fn = lambda: "fake-token"
+    client = get_sync_client("azure", "https://my.azure.com", None, azure_ad_token_provider=provider_fn)
+    assert client._azure_ad_token_provider is provider_fn
+
+
+def test_azure_ad_token_provider_forwarded_async():
+    """azure_ad_token_provider is passed to AsyncAzureOpenAI constructor."""
+    provider_fn = lambda: "fake-token"
+    client = get_async_client("azure", "https://my.azure.com", None, azure_ad_token_provider=provider_fn)
+    assert client._azure_ad_token_provider is provider_fn
+
+
+def test_azure_different_token_providers_not_cached():
+    """Different azure_ad_token_provider functions produce different clients."""
+    fn1 = lambda: "token-a"
+    fn2 = lambda: "token-b"
+    c1 = get_sync_client("azure", "https://x.azure.com", None, azure_ad_token_provider=fn1)
+    c2 = get_sync_client("azure", "https://x.azure.com", None, azure_ad_token_provider=fn2)
+    assert c1 is not c2
+
+
+def test_azure_same_token_provider_cached():
+    """Same azure_ad_token_provider function reuses cached client."""
+    fn = lambda: "token"
+    c1 = get_sync_client("azure", "https://x.azure.com", None, azure_ad_token_provider=fn)
+    c2 = get_sync_client("azure", "https://x.azure.com", None, azure_ad_token_provider=fn)
+    assert c1 is c2
+
+
+def test_azure_none_token_provider_backwards_compat():
+    """Omitting azure_ad_token_provider works as before."""
+    import openai
+
+    client = get_sync_client("azure", "https://my.azure.com", "sk-az", api_version="2024-02-01")
+    assert isinstance(client, openai.AzureOpenAI)

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -47,7 +47,7 @@ def test_prepare_call_strips_litellm_kwargs():
         "temperature": 0.5,
         "api_key": "sk-test",
     }
-    provider, model, base_url, api_key, api_version, num_retries, cleaned = _prepare_call("openai/gpt-4o", kwargs)
+    provider, model, base_url, api_key, api_version, num_retries, _atp, cleaned = _prepare_call("openai/gpt-4o", kwargs)
     assert provider == "openai"
     assert model == "gpt-4o"
     assert num_retries == 3
@@ -60,7 +60,7 @@ def test_prepare_call_strips_litellm_kwargs():
 
 def test_prepare_call_headers():
     kwargs = {"headers": {"X-Custom": "val"}, "api_key": "k"}
-    _, _, _, _, _, _, cleaned = _prepare_call("openai/gpt-4o", kwargs)
+    _, _, _, _, _, _, _, cleaned = _prepare_call("openai/gpt-4o", kwargs)
     assert cleaned["extra_headers"] == {"X-Custom": "val"}
     assert "headers" not in cleaned
 
@@ -227,6 +227,44 @@ def test_completion_normalizes_pydantic_response_format(mock_get_client):
     assert isinstance(rf, dict)
     assert rf["type"] == "json_schema"
     assert rf["json_schema"]["name"] == "Answer"
+
+
+# --- azure_ad_token_provider passthrough ---
+
+
+def test_prepare_call_pops_azure_ad_token_provider():
+    """azure_ad_token_provider is extracted from kwargs, not left for create()."""
+    provider_fn = lambda: "fake-token"
+    kwargs = {"temperature": 0.5, "azure_ad_token_provider": provider_fn, "api_key": "sk-test"}
+    result = _prepare_call("azure/gpt-4o", kwargs)
+    provider, model, base_url, api_key, api_version, num_retries, atp, cleaned = result
+    assert "azure_ad_token_provider" not in cleaned
+    assert atp is provider_fn
+
+
+@mock.patch("litelm._completion.get_sync_client")
+def test_completion_forwards_azure_ad_token_provider_to_client(mock_get_client):
+    """azure_ad_token_provider reaches get_sync_client, not create()."""
+    provider_fn = lambda: "fake-token"
+    mock_client = mock.MagicMock()
+    mock_client.chat.completions.create.return_value = _mock_completion()
+    mock_get_client.return_value = mock_client
+
+    completion(
+        "azure/gpt-4o",
+        messages=[{"role": "user", "content": "hi"}],
+        api_key="sk-test",
+        api_base="https://my.azure.com",
+        azure_ad_token_provider=provider_fn,
+    )
+
+    # Should be forwarded to get_sync_client
+    get_client_kwargs = mock_get_client.call_args[1]
+    assert get_client_kwargs.get("azure_ad_token_provider") is provider_fn
+
+    # Should NOT leak into create()
+    create_kwargs = mock_client.chat.completions.create.call_args[1]
+    assert "azure_ad_token_provider" not in create_kwargs
 
 
 @mock.patch("litelm._completion.get_async_client")

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -232,20 +232,22 @@ def test_completion_normalizes_pydantic_response_format(mock_get_client):
 # --- azure_ad_token_provider passthrough ---
 
 
+def _fake_token_provider():
+    return "fake-token"
+
+
 def test_prepare_call_pops_azure_ad_token_provider():
     """azure_ad_token_provider is extracted from kwargs, not left for create()."""
-    provider_fn = lambda: "fake-token"
-    kwargs = {"temperature": 0.5, "azure_ad_token_provider": provider_fn, "api_key": "sk-test"}
+    kwargs = {"temperature": 0.5, "azure_ad_token_provider": _fake_token_provider, "api_key": "sk-test"}
     result = _prepare_call("azure/gpt-4o", kwargs)
     provider, model, base_url, api_key, api_version, num_retries, atp, cleaned = result
     assert "azure_ad_token_provider" not in cleaned
-    assert atp is provider_fn
+    assert atp is _fake_token_provider
 
 
 @mock.patch("litelm._completion.get_sync_client")
 def test_completion_forwards_azure_ad_token_provider_to_client(mock_get_client):
     """azure_ad_token_provider reaches get_sync_client, not create()."""
-    provider_fn = lambda: "fake-token"
     mock_client = mock.MagicMock()
     mock_client.chat.completions.create.return_value = _mock_completion()
     mock_get_client.return_value = mock_client
@@ -255,12 +257,12 @@ def test_completion_forwards_azure_ad_token_provider_to_client(mock_get_client):
         messages=[{"role": "user", "content": "hi"}],
         api_key="sk-test",
         api_base="https://my.azure.com",
-        azure_ad_token_provider=provider_fn,
+        azure_ad_token_provider=_fake_token_provider,
     )
 
     # Should be forwarded to get_sync_client
     get_client_kwargs = mock_get_client.call_args[1]
-    assert get_client_kwargs.get("azure_ad_token_provider") is provider_fn
+    assert get_client_kwargs.get("azure_ad_token_provider") is _fake_token_provider
 
     # Should NOT leak into create()
     create_kwargs = mock_client.chat.completions.create.call_args[1]

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -627,7 +627,7 @@ def test_openai_pydantic_response_format():
 
 def _azure_env():
     """Extract Azure base endpoint and api_version from AZURE_OPENAI_URL."""
-    from urllib.parse import urlparse, parse_qs
+    from urllib.parse import parse_qs, urlparse
 
     raw = os.environ.get("AZURE_OPENAI_URL", "")
     parsed = urlparse(raw)

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -622,6 +622,65 @@ def test_openai_pydantic_response_format():
     assert "reasoning" in parsed
 
 
+# --- Azure OpenAI ---
+
+
+def _azure_env():
+    """Extract Azure base endpoint and api_version from AZURE_OPENAI_URL."""
+    from urllib.parse import urlparse, parse_qs
+
+    raw = os.environ.get("AZURE_OPENAI_URL", "")
+    parsed = urlparse(raw)
+    base = f"{parsed.scheme}://{parsed.netloc}"
+    qs = parse_qs(parsed.query)
+    version = qs.get("api-version", [None])[0]
+    return base, version
+
+
+@pytest.mark.live
+@pytest.mark.skipif(
+    not all(os.environ.get(k) for k in ("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_URL", "AZURE_OPENAI_MODEL")),
+    reason="Azure credentials not set",
+)
+def test_azure_openai():
+    """Basic Azure OpenAI completion."""
+    base, version = _azure_env()
+    kwargs = {"api_key": os.environ["AZURE_OPENAI_API_KEY"], "api_base": base}
+    if version:
+        kwargs["api_version"] = version
+    resp = litelm.completion(
+        model=f"azure/{os.environ['AZURE_OPENAI_MODEL']}",
+        messages=[{"role": "user", "content": "Say hello in one sentence."}],
+        **kwargs,
+    )
+    assert_dspy_response_contract(resp)
+
+
+@pytest.mark.live
+@pytest.mark.skipif(
+    not all(os.environ.get(k) for k in ("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_URL", "AZURE_OPENAI_MODEL")),
+    reason="Azure credentials not set",
+)
+def test_azure_openai_streaming():
+    """Azure OpenAI streaming completion."""
+    base, version = _azure_env()
+    kwargs = {"api_key": os.environ["AZURE_OPENAI_API_KEY"], "api_base": base}
+    if version:
+        kwargs["api_version"] = version
+    chunks = list(
+        litelm.completion(
+            model=f"azure/{os.environ['AZURE_OPENAI_MODEL']}",
+            messages=[{"role": "user", "content": "Say hello in one sentence."}],
+            stream=True,
+            stream_options={"include_usage": True},
+            **kwargs,
+        )
+    )
+    assert_stream_contract(chunks)
+    response = litelm.stream_chunk_builder(chunks)
+    assert_dspy_response_contract(response)
+
+
 @pytest.mark.live
 @pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY"), reason="no OPENAI_API_KEY")
 def test_openai_pydantic_response_format_streaming():


### PR DESCRIPTION
## Summary
- Thread `azure_ad_token_provider` from completion kwargs through `_prepare_call` → `get_sync/async_client` → `_make_client` → `AzureOpenAI()` constructor
- Enables Entra ID (Azure AD) token-based auth without API keys
- Cache key uses `id()` of the callable so different providers get separate clients

## Test plan
- [x] Unit: token provider forwarded to sync/async AzureOpenAI constructor
- [x] Unit: different token providers produce different cached clients
- [x] Unit: `azure_ad_token_provider` popped from kwargs, not leaked to `create()`
- [x] Unit: backwards compat — omitting param works as before
- [x] Live: basic Azure OpenAI completion + streaming with real credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)